### PR TITLE
Add support for Backbone 0.9.10+

### DIFF
--- a/backbone-websql.js
+++ b/backbone-websql.js
@@ -43,6 +43,7 @@ var WebSQLStore = function (db, tableName, initSuccessCallback, initErrorCallbac
 	//});
 	this._executeSql("CREATE TABLE IF NOT EXISTS `" + tableName + "` (`id` unique, `value`);",null,success, error);
 };
+WebSQLStore.newCallbacks = Backbone.VERSION == '0.9.10' || parseInt(Backbone.VERSION.split('.')[0]) >= 1;
 WebSQLStore.debug = false;
 _.extend(WebSQLStore.prototype,{
 	
@@ -124,13 +125,20 @@ Backbone.sync = function (method, model, options) {
 			}
 		} 
 		
-		options.success(result);
+		if (WebSQLStore.newCallbacks)
+			options.success(model, result, options);
+		else
+			options.success(result);
 	};
 	error = function (tx,error) {
 		window.console.error("sql error");
 		window.console.error(error);
 		window.console.error(tx);
-		options.error(error);
+
+		if (WebSQLStore.newCallbacks)
+			options.error(model, error, options);
+		else
+			options.error(error);
 	};
 	
 	switch(method) {


### PR DESCRIPTION
@MarrLiss,

In order to work with Backbone 0.9.10+, Backbone.sync implementations need to send `model, resp, options` instead of `resp, status, xhr` to the `success()` and `error()` callbacks. This change was not documented in the Backbone changelog (I might see if I can add it), but it is visible in the [Backbone 0.9.10 Diff](https://github.com/documentcloud/backbone/compare/0.9.9...0.9.10) (just search for "success" or "error" in the "Files Changed" tab).

This pull request supports the new callback style while maintaining backward compatibility with the old style if `Backbone.VERSION` is less than 0.9.10.

Note that if you merge #6, the new call to `success()` inside `successFind()` will need similar treatment. Let me know if you merge it, so I can update this pull request to take care of that.
