### PR TITLE
Added support for explicit transactions

### DIFF
--- a/backbone-websql.js
+++ b/backbone-websql.js
@@ -85,7 +85,7 @@ _.extend(WebSQLStore.prototype,{
 	
 	update: function (model, success, error, options) {
 		if (WebSQLStore.insertOrReplace)
-			return this.create(model, success, error);
+			return this.create(model, success, error, options);
 
 		//window.console.log("sql update")
 		var id = (model.attributes[model.idAttribute] || model.attributes.id);

--- a/backbone-websql.js
+++ b/backbone-websql.js
@@ -41,13 +41,13 @@ var WebSQLStore = function (db, tableName, initSuccessCallback, initErrorCallbac
 	//db.transaction (function(tx) {
 	//	tx.executeSql("CREATE TABLE IF NOT EXISTS `" + tableName + "` (`id` unique, `value`);",[],success, error);
 	//});
-	this._executeSql("CREATE TABLE IF NOT EXISTS `" + tableName + "` (`id` unique, `value`);",null,success, error);
+	this._executeSql("CREATE TABLE IF NOT EXISTS `" + tableName + "` (`id` unique, `value`);",null,success, error, {});
 };
 WebSQLStore.debug = false;
 WebSQLStore.insertOrReplace = false;
 _.extend(WebSQLStore.prototype,{
 	
-	create: function (model,success,error) {
+	create: function (model,success,error,options) {
 		//when you want use your id as identifier, use apiid attribute
 		if(!model.attributes[model.idAttribute]) {
 			// Reference model.attributes.apiid for backward compatibility.
@@ -63,33 +63,33 @@ _.extend(WebSQLStore.prototype,{
 		}
 
 		var orReplace = WebSQLStore.insertOrReplace ? ' OR REPLACE' : '';
-		this._executeSql("INSERT" + orReplace + " INTO `" + this.tableName + "`(`id`,`value`)VALUES(?,?);",[model.attributes[model.idAttribute], JSON.stringify(model.toJSON())], success, error);
+		this._executeSql("INSERT" + orReplace + " INTO `" + this.tableName + "`(`id`,`value`)VALUES(?,?);",[model.attributes[model.idAttribute], JSON.stringify(model.toJSON())], success, error, options);
 	},
 	
-	destroy: function (model, success, error) {
+	destroy: function (model, success, error, options) {
 		//window.console.log("sql destroy");
 		var id = (model.attributes[model.idAttribute] || model.attributes.id);
-		this._executeSql("DELETE FROM `"+this.tableName+"` WHERE(`id`=?);",[model.attributes[model.idAttribute]],success, error);
+		this._executeSql("DELETE FROM `"+this.tableName+"` WHERE(`id`=?);",[model.attributes[model.idAttribute]],success, error, options);
 	},
 	
-	find: function (model, success, error) {
+	find: function (model, success, error, options) {
 		//window.console.log("sql find");
 		var id = (model.attributes[model.idAttribute] || model.attributes.id);
-		this._executeSql("SELECT `id`, `value` FROM `"+this.tableName+"` WHERE(`id`=?);",[model.attributes[model.idAttribute]], success, error);
+		this._executeSql("SELECT `id`, `value` FROM `"+this.tableName+"` WHERE(`id`=?);",[model.attributes[model.idAttribute]], success, error, options);
 	},
 	
-	findAll: function (model, success,error) {
+	findAll: function (model, success,error, options) {
 		//window.console.log("sql findAll");
-		this._executeSql("SELECT `id`, `value` FROM `"+this.tableName+"`;",null, success, error);			
+		this._executeSql("SELECT `id`, `value` FROM `"+this.tableName+"`;",null, success, error, options);			
 	},
 	
-	update: function (model, success, error) {
+	update: function (model, success, error, options) {
 		if (WebSQLStore.insertOrReplace)
 			return this.create(model, success, error);
 
 		//window.console.log("sql update")
 		var id = (model.attributes[model.idAttribute] || model.attributes.id);
-		this._executeSql("UPDATE `"+this.tableName+"` SET `value`=? WHERE(`id`=?);",[JSON.stringify(model.toJSON()), model.attributes[model.idAttribute]], success, error);
+		this._executeSql("UPDATE `"+this.tableName+"` SET `value`=? WHERE(`id`=?);",[JSON.stringify(model.toJSON()), model.attributes[model.idAttribute]], success, error, options);
 	},
 	
 	_save: function (model, success, error) {
@@ -100,7 +100,7 @@ _.extend(WebSQLStore.prototype,{
 		});
 	},
 	
-	_executeSql: function (SQL, params, successCallback, errorCallback) {
+	_executeSql: function (SQL, params, successCallback, errorCallback, options) {
 		var success = function(tx,result) {
 			if(WebSQLStore.debug) {window.console.log(SQL, params, " - finished");}
 			if(successCallback) successCallback(tx,result);
@@ -109,9 +109,15 @@ _.extend(WebSQLStore.prototype,{
 			if(WebSQLStore.debug) {window.console.error(SQL, params, " - error: " + error)};
 			if(errorCallback) errorCallback(tx,error);
 		};
-		this.db.transaction(function(tx) {
-			tx.executeSql(SQL, params, success, error);
-		});
+		
+		if (options.transaction) {
+			options.transaction.executeSql(SQL, params, success, error);
+		}
+		else {
+			this.db.transaction(function(tx) {
+				tx.executeSql(SQL, params, success, error);
+			});
+		}
 	}
 });
 
@@ -149,21 +155,20 @@ Backbone.sync = function (method, model, options) {
 	};
 	
 	switch(method) {
-		
 		case "read":	
 			if(model.attributes && model.attributes[model.idAttribute]){
 				isSingleResult = true;
-				store.find(model,success,error)
+				store.find(model,success,error,options)
 			}else{
-				store.findAll(model, success, error)
+				store.findAll(model, success, error, options)
 			}			
 
 			break;
-		case "create":	store.create(model,success,error);
+		case "create":	store.create(model,success,error,options);
 			break;
-		case "update":	store.update(model,success,error);
+		case "update":	store.update(model,success,error,options);
 			break;
-		case "delete":	store.destroy(model,success,error);
+		case "delete":	store.destroy(model,success,error,options);
 			break;
 		default:
 			window.console.error(method);


### PR DESCRIPTION
The Web SQL Database implementation on the iPhone is very slow if every `INSERT` is done in its own transaction. This pull request allows the client code to specify a `transaction` property on the `options` object so that multiple `save()`s are done in a single transaction, like this:

``` javascript
db.transaction(function (tx) {
  model_1.save(null, {'transaction': tx});
  model_2.save(null, {'transaction': tx});
  model_3.save(null, {'transaction': tx});
});
```

This is much faster and also allows client code to group related or interdependent database operations so that they succeed or fail together.
